### PR TITLE
feat: Google Docs document generation module (promoter assignment)

### DIFF
--- a/drizzle/0016_document_generation.sql
+++ b/drizzle/0016_document_generation.sql
@@ -1,0 +1,90 @@
+CREATE TABLE IF NOT EXISTS `promoter_assignments` (
+  `id` char(36) NOT NULL PRIMARY KEY,
+  `company_id` int NOT NULL,
+  `first_party_company_id` int NOT NULL,
+  `second_party_company_id` int NOT NULL,
+  `promoter_employee_id` int NOT NULL,
+  `location_ar` varchar(500),
+  `location_en` varchar(500),
+  `start_date` date NOT NULL,
+  `end_date` date NOT NULL,
+  `status` varchar(50) NOT NULL DEFAULT 'active',
+  `contract_reference_number` varchar(100),
+  `issue_date` date,
+  `created_at` timestamp DEFAULT (now()) NOT NULL,
+  `updated_at` timestamp DEFAULT (now()) ON UPDATE CURRENT_TIMESTAMP NOT NULL,
+  INDEX `idx_pa_company` (`company_id`),
+  INDEX `idx_pa_first_party` (`first_party_company_id`),
+  INDEX `idx_pa_second_party` (`second_party_company_id`),
+  INDEX `idx_pa_employee` (`promoter_employee_id`)
+);
+
+CREATE TABLE IF NOT EXISTS `document_templates` (
+  `id` char(36) NOT NULL PRIMARY KEY,
+  `company_id` int NOT NULL DEFAULT 0,
+  `key` varchar(191) NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `category` varchar(100) NOT NULL,
+  `entity_type` varchar(100) NOT NULL,
+  `document_source` varchar(50) NOT NULL DEFAULT 'google_docs',
+  `google_doc_id` varchar(255),
+  `language` varchar(32) NOT NULL,
+  `version` int NOT NULL DEFAULT 1,
+  `status` varchar(32) NOT NULL DEFAULT 'draft',
+  `output_formats` json NOT NULL DEFAULT (json_array('pdf')),
+  `created_at` timestamp DEFAULT (now()) NOT NULL,
+  `updated_at` timestamp DEFAULT (now()) ON UPDATE CURRENT_TIMESTAMP NOT NULL,
+  INDEX `idx_dt_company` (`company_id`),
+  INDEX `idx_dt_entity` (`entity_type`),
+  UNIQUE `uq_document_templates_key_company` (`key`, `company_id`)
+);
+
+CREATE TABLE IF NOT EXISTS `document_template_placeholders` (
+  `id` char(36) NOT NULL PRIMARY KEY,
+  `template_id` char(36) NOT NULL,
+  `placeholder` varchar(191) NOT NULL,
+  `label` varchar(255) NOT NULL,
+  `source_path` varchar(255) NOT NULL,
+  `data_type` varchar(32) NOT NULL DEFAULT 'string',
+  `required` boolean NOT NULL DEFAULT true,
+  `default_value` text,
+  `created_at` timestamp DEFAULT (now()) NOT NULL,
+  INDEX `idx_dtp_template` (`template_id`),
+  UNIQUE `uq_dtp_template_placeholder` (`template_id`, `placeholder`),
+  CONSTRAINT `document_template_placeholders_template_id_document_templates_id_fk`
+    FOREIGN KEY (`template_id`) REFERENCES `document_templates`(`id`) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS `generated_documents` (
+  `id` char(36) NOT NULL PRIMARY KEY,
+  `template_id` char(36) NOT NULL,
+  `entity_type` varchar(100) NOT NULL,
+  `entity_id` char(36) NOT NULL,
+  `output_format` varchar(32) NOT NULL,
+  `source_google_doc_id` varchar(255),
+  `generated_google_doc_id` varchar(255),
+  `file_url` text,
+  `file_path` varchar(1024),
+  `status` varchar(50) NOT NULL DEFAULT 'pending',
+  `generated_by` int,
+  `company_id` int NOT NULL,
+  `metadata` json NOT NULL DEFAULT (json_object()),
+  `created_at` timestamp DEFAULT (now()) NOT NULL,
+  INDEX `idx_gd_company` (`company_id`),
+  INDEX `idx_gd_template` (`template_id`),
+  INDEX `idx_gd_entity` (`entity_type`, `entity_id`),
+  CONSTRAINT `generated_documents_template_id_document_templates_id_fk`
+    FOREIGN KEY (`template_id`) REFERENCES `document_templates`(`id`)
+);
+
+CREATE TABLE IF NOT EXISTS `document_generation_audit_logs` (
+  `id` char(36) NOT NULL PRIMARY KEY,
+  `generated_document_id` char(36) NOT NULL,
+  `action` varchar(100) NOT NULL,
+  `actor_id` int,
+  `details` json NOT NULL DEFAULT (json_object()),
+  `created_at` timestamp DEFAULT (now()) NOT NULL,
+  INDEX `idx_dgal_doc` (`generated_document_id`),
+  CONSTRAINT `document_generation_audit_logs_generated_document_id_fk`
+    FOREIGN KEY (`generated_document_id`) REFERENCES `generated_documents`(`id`) ON DELETE CASCADE
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1775164100006,
       "tag": "0002_smiling_meteorite",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "5",
+      "when": 1775000000000,
+      "tag": "0016_document_generation",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1,5 +1,6 @@
 import {
   boolean,
+  char,
   date,
   decimal,
   index,
@@ -9,6 +10,7 @@ import {
   mysqlTable,
   text,
   timestamp,
+  unique,
   varchar,
 } from "drizzle-orm/mysql-core";
 
@@ -2513,3 +2515,131 @@ export const workforceHealthSnapshots = mysqlTable("workforce_health_snapshots",
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 export type WorkforceHealthSnapshot = typeof workforceHealthSnapshots.$inferSelect;
+
+// ─── PROMOTER ASSIGNMENTS (HR / contracts — Google Doc generation source) ─────
+export const promoterAssignments = mysqlTable(
+  "promoter_assignments",
+  {
+    id: char("id", { length: 36 }).primaryKey(),
+    companyId: int("company_id").notNull(),
+    firstPartyCompanyId: int("first_party_company_id").notNull(),
+    secondPartyCompanyId: int("second_party_company_id").notNull(),
+    promoterEmployeeId: int("promoter_employee_id").notNull(),
+    locationAr: varchar("location_ar", { length: 500 }),
+    locationEn: varchar("location_en", { length: 500 }),
+    startDate: date("start_date").notNull(),
+    endDate: date("end_date").notNull(),
+    status: varchar("status", { length: 50 }).notNull().default("active"),
+    contractReferenceNumber: varchar("contract_reference_number", { length: 100 }),
+    issueDate: date("issue_date"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().onUpdateNow().notNull(),
+  },
+  (t) => [
+    index("idx_pa_company").on(t.companyId),
+    index("idx_pa_first_party").on(t.firstPartyCompanyId),
+    index("idx_pa_second_party").on(t.secondPartyCompanyId),
+    index("idx_pa_employee").on(t.promoterEmployeeId),
+  ]
+);
+export type PromoterAssignment = typeof promoterAssignments.$inferSelect;
+export type InsertPromoterAssignment = typeof promoterAssignments.$inferInsert;
+
+// ─── DOCUMENT GENERATION (Google Docs templates & outputs) ────────────────────
+export const documentTemplates = mysqlTable(
+  "document_templates",
+  {
+    id: char("id", { length: 36 }).primaryKey(),
+    /** 0 = platform-wide template; otherwise owning company id */
+    companyId: int("company_id").notNull().default(0),
+    key: varchar("key", { length: 191 }).notNull(),
+    name: varchar("name", { length: 255 }).notNull(),
+    category: varchar("category", { length: 100 }).notNull(),
+    entityType: varchar("entity_type", { length: 100 }).notNull(),
+    documentSource: varchar("document_source", { length: 50 }).notNull().default("google_docs"),
+    googleDocId: varchar("google_doc_id", { length: 255 }),
+    language: varchar("language", { length: 32 }).notNull(),
+    version: int("version").notNull().default(1),
+    status: varchar("status", { length: 32 }).notNull().default("draft"),
+    outputFormats: json("output_formats").$type<string[]>().notNull().default(["pdf"]),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().onUpdateNow().notNull(),
+  },
+  (t) => [
+    index("idx_dt_company").on(t.companyId),
+    index("idx_dt_entity").on(t.entityType),
+    unique("uq_document_templates_key_company").on(t.key, t.companyId),
+  ]
+);
+export type DocumentTemplate = typeof documentTemplates.$inferSelect;
+export type InsertDocumentTemplate = typeof documentTemplates.$inferInsert;
+
+export const documentTemplatePlaceholders = mysqlTable(
+  "document_template_placeholders",
+  {
+    id: char("id", { length: 36 }).primaryKey(),
+    templateId: char("template_id", { length: 36 })
+      .notNull()
+      .references(() => documentTemplates.id, { onDelete: "cascade" }),
+    placeholder: varchar("placeholder", { length: 191 }).notNull(),
+    label: varchar("label", { length: 255 }).notNull(),
+    sourcePath: varchar("source_path", { length: 255 }).notNull(),
+    dataType: varchar("data_type", { length: 32 }).notNull().default("string"),
+    required: boolean("required").notNull().default(true),
+    defaultValue: text("default_value"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (t) => [
+    index("idx_dtp_template").on(t.templateId),
+    unique("uq_dtp_template_placeholder").on(t.templateId, t.placeholder),
+  ]
+);
+export type DocumentTemplatePlaceholder = typeof documentTemplatePlaceholders.$inferSelect;
+export type InsertDocumentTemplatePlaceholder = typeof documentTemplatePlaceholders.$inferInsert;
+
+export const generatedDocuments = mysqlTable(
+  "generated_documents",
+  {
+    id: char("id", { length: 36 }).primaryKey(),
+    templateId: char("template_id", { length: 36 })
+      .notNull()
+      .references(() => documentTemplates.id),
+    entityType: varchar("entity_type", { length: 100 }).notNull(),
+    entityId: char("entity_id", { length: 36 }).notNull(),
+    outputFormat: varchar("output_format", { length: 32 }).notNull(),
+    sourceGoogleDocId: varchar("source_google_doc_id", { length: 255 }),
+    generatedGoogleDocId: varchar("generated_google_doc_id", { length: 255 }),
+    fileUrl: text("file_url"),
+    /** Storage key from Forge upload */
+    filePath: varchar("file_path", { length: 1024 }),
+    status: varchar("status", { length: 50 }).notNull().default("pending"),
+    generatedBy: int("generated_by"),
+    companyId: int("company_id").notNull(),
+    metadata: json("metadata").$type<Record<string, unknown>>().notNull().default({}),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (t) => [
+    index("idx_gd_company").on(t.companyId),
+    index("idx_gd_template").on(t.templateId),
+    index("idx_gd_entity").on(t.entityType, t.entityId),
+  ]
+);
+export type GeneratedDocument = typeof generatedDocuments.$inferSelect;
+export type InsertGeneratedDocument = typeof generatedDocuments.$inferInsert;
+
+export const documentGenerationAuditLogs = mysqlTable(
+  "document_generation_audit_logs",
+  {
+    id: char("id", { length: 36 }).primaryKey(),
+    generatedDocumentId: char("generated_document_id", { length: 36 })
+      .notNull()
+      .references(() => generatedDocuments.id, { onDelete: "cascade" }),
+    action: varchar("action", { length: 100 }).notNull(),
+    actorId: int("actor_id"),
+    details: json("details").$type<Record<string, unknown>>().notNull().default({}),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (t) => [index("idx_dgal_doc").on(t.generatedDocumentId)]
+);
+export type DocumentGenerationAuditLog = typeof documentGenerationAuditLogs.$inferSelect;
+export type InsertDocumentGenerationAuditLog = typeof documentGenerationAuditLogs.$inferInsert;

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "express": "^4.21.2",
     "express-rate-limit": "^8.3.1",
     "framer-motion": "^12.23.22",
+    "google-auth-library": "^10.6.2",
+    "googleapis": "^171.4.0",
     "helmet": "^8.1.0",
     "input-otp": "^1.4.2",
     "jose": "6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,12 @@ importers:
       framer-motion:
         specifier: ^12.23.22
         version: 12.23.22(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      google-auth-library:
+        specifier: ^10.6.2
+        version: 10.6.2
+      googleapis:
+        specifier: ^171.4.0
+        version: 171.4.0
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
@@ -2550,6 +2556,10 @@ packages:
     resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
     engines: {node: '>=0.8'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2610,6 +2620,9 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -2624,6 +2637,9 @@ packages:
     resolution: {integrity: sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -2945,6 +2961,10 @@ packages:
   dagre-d3-es@7.0.11:
     resolution: {integrity: sha512-tvlJLyQf834SylNKax8Wkzco/1ias1OPw8DcUMDE7oUIoSEW25riQVuiu/0OWEFqT0cxHT3Pa9/D82Jr47IONw==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -3140,6 +3160,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -3284,6 +3307,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
@@ -3303,6 +3330,10 @@ packages:
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -3341,6 +3372,14 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
 
@@ -3365,6 +3404,22 @@ packages:
 
   globals@15.15.0:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
+    engines: {node: '>=18'}
+
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
+  googleapis-common@8.0.1:
+    resolution: {integrity: sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==}
+    engines: {node: '>=18.0.0'}
+
+  googleapis@171.4.0:
+    resolution: {integrity: sha512-xybFL2SmmUgIifgsbsRQYRdNrSAYwxWZDmkZTGjUIaRnX5jPqR8el/cEvo6rCqh7iaZx6MfEPS/lrDgZ0bymkg==}
     engines: {node: '>=18'}
 
   gopd@1.2.0:
@@ -3445,6 +3500,10 @@ packages:
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -3545,10 +3604,19 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   katex@0.16.25:
     resolution: {integrity: sha512-woHRUZ/iF23GBP1dkDQMh1QBad9dmr8/PAwNA54VrSOVYgI12MAcE14TqnDdQOdzyEonGzMepYnqBMYdsoAr8Q==}
@@ -3929,6 +3997,15 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-releases@2.0.23:
     resolution: {integrity: sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==}
@@ -4539,6 +4616,9 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -4731,6 +4811,10 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -7335,6 +7419,8 @@ snapshots:
 
   adler-32@1.3.1: {}
 
+  agent-base@7.1.4: {}
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@5.2.0: {}
@@ -7387,6 +7473,8 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  bignumber.js@9.3.1: {}
+
   body-parser@1.20.3:
     dependencies:
       bytes: 3.1.2
@@ -7417,6 +7505,8 @@ snapshots:
       electron-to-chromium: 1.5.230
       node-releases: 2.0.23
       update-browserslist-db: 1.1.3(browserslist@4.26.3)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -7746,6 +7836,8 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.17.21
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -7834,6 +7926,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -8045,6 +8141,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   finalhandler@1.3.1:
     dependencies:
       debug: 2.6.9
@@ -8079,6 +8180,10 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded@0.2.0: {}
 
   frac@1.1.2: {}
@@ -8100,6 +8205,22 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   generate-function@2.3.1:
     dependencies:
@@ -8132,6 +8253,36 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   globals@15.15.0: {}
+
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
+  googleapis-common@8.0.1:
+    dependencies:
+      extend: 3.0.2
+      gaxios: 7.1.4
+      google-auth-library: 10.6.2
+      qs: 6.13.0
+      url-template: 2.0.8
+    transitivePeerDependencies:
+      - supports-color
+
+  googleapis@171.4.0:
+    dependencies:
+      google-auth-library: 10.6.2
+      googleapis-common: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   gopd@1.2.0: {}
 
@@ -8289,6 +8440,13 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -8377,7 +8535,22 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json5@2.2.3: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   katex@0.16.25:
     dependencies:
@@ -8961,6 +9134,14 @@ snapshots:
     dependencies:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-releases@2.0.23: {}
 
@@ -9670,6 +9851,8 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  url-template@2.0.8: {}
+
   use-callback-ref@1.3.3(@types/react@19.2.1)(react@19.2.1):
     dependencies:
       react: 19.2.1
@@ -9851,6 +10034,8 @@ snapshots:
       xml-name-validator: 5.0.0
 
   web-namespaces@2.0.1: {}
+
+  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@8.0.1: {}
 

--- a/server/_core/env.ts
+++ b/server/_core/env.ts
@@ -8,6 +8,8 @@ export const ENV = {
   forgeApiUrl: process.env.BUILT_IN_FORGE_API_URL ?? "",
   forgeApiKey: process.env.BUILT_IN_FORGE_API_KEY ?? "",
   resendApiKey: process.env.RESEND_API_KEY ?? "",
+  /** JSON string of a Google Cloud service account with Drive + Docs API access */
+  googleDocsServiceAccountJson: process.env.GOOGLE_DOCS_SERVICE_ACCOUNT_JSON ?? "",
 };
 
 /**

--- a/server/modules/document-generation/documentGeneration.repository.ts
+++ b/server/modules/document-generation/documentGeneration.repository.ts
@@ -1,0 +1,111 @@
+import { and, eq, or } from "drizzle-orm";
+import {
+  documentGenerationAuditLogs,
+  documentTemplatePlaceholders,
+  documentTemplates,
+  generatedDocuments,
+} from "../../../drizzle/schema";
+import type { getDb } from "../../db";
+
+type AppDb = NonNullable<Awaited<ReturnType<typeof getDb>>>;
+
+export async function findTemplateByKeyForCompany(
+  db: AppDb,
+  key: string,
+  activeCompanyId: number
+) {
+  const rows = await db
+    .select()
+    .from(documentTemplates)
+    .where(
+      and(
+        eq(documentTemplates.key, key),
+        or(eq(documentTemplates.companyId, activeCompanyId), eq(documentTemplates.companyId, 0))
+      )
+    );
+
+  const companySpecific = rows.find((r) => r.companyId === activeCompanyId);
+  if (companySpecific) return companySpecific;
+  return rows.find((r) => r.companyId === 0) ?? null;
+}
+
+export async function listPlaceholdersForTemplate(db: AppDb, templateId: string) {
+  return db
+    .select()
+    .from(documentTemplatePlaceholders)
+    .where(eq(documentTemplatePlaceholders.templateId, templateId));
+}
+
+export async function insertGeneratedDocument(
+  db: AppDb,
+  row: typeof generatedDocuments.$inferInsert
+) {
+  await db.insert(generatedDocuments).values(row);
+}
+
+export async function insertDocumentGenerationAuditLog(
+  db: AppDb,
+  row: typeof documentGenerationAuditLogs.$inferInsert
+) {
+  await db.insert(documentGenerationAuditLogs).values(row);
+}
+
+/** Idempotent bootstrap: inserts platform template + placeholders if key missing. */
+export async function seedDocumentGenerationBootstrap(db: AppDb): Promise<void> {
+  const key = "promoter_assignment_contract_bilingual";
+  const existing = await db
+    .select({ id: documentTemplates.id })
+    .from(documentTemplates)
+    .where(and(eq(documentTemplates.key, key), eq(documentTemplates.companyId, 0)))
+    .limit(1);
+
+  if (existing.length > 0) return;
+
+  const templateId = crypto.randomUUID();
+  await db.insert(documentTemplates).values({
+    id: templateId,
+    companyId: 0,
+    key,
+    name: "Promoter Assignment Contract - Bilingual",
+    category: "contract",
+    entityType: "promoter_assignment",
+    documentSource: "google_docs",
+    googleDocId: "1dG719K4jYFrEh8O9VChyMYWblflxW2tdFp2n4gpVhs0",
+    language: "ar-en",
+    version: 1,
+    status: "active",
+    outputFormats: ["pdf"],
+  });
+
+  const ph = (
+    placeholder: string,
+    label: string,
+    sourcePath: string,
+    dataType: string
+  ) => ({
+    id: crypto.randomUUID(),
+    templateId,
+    placeholder,
+    label,
+    sourcePath,
+    dataType,
+    required: true as const,
+    defaultValue: null as string | null,
+  });
+
+  await db.insert(documentTemplatePlaceholders).values([
+    ph("first_party_name_ar", "First party (AR)", "first_party.company_name_ar", "string"),
+    ph("first_party_name_en", "First party (EN)", "first_party.company_name_en", "string"),
+    ph("first_party_crn", "First party CR", "first_party.cr_number", "string"),
+    ph("second_party_name_ar", "Second party (AR)", "second_party.company_name_ar", "string"),
+    ph("second_party_name_en", "Second party (EN)", "second_party.company_name_en", "string"),
+    ph("second_party_crn", "Second party CR", "second_party.cr_number", "string"),
+    ph("location_ar", "Location AR", "assignment.location_ar", "string"),
+    ph("location_en", "Location EN", "assignment.location_en", "string"),
+    ph("promoter_name_ar", "Promoter name AR", "promoter.full_name_ar", "string"),
+    ph("promoter_name_en", "Promoter name EN", "promoter.full_name_en", "string"),
+    ph("id_card_number", "ID card", "promoter.id_card_number", "string"),
+    ph("contract_start_date", "Start date", "assignment.start_date", "date"),
+    ph("contract_end_date", "End date", "assignment.end_date", "date"),
+  ]);
+}

--- a/server/modules/document-generation/documentGeneration.service.test.ts
+++ b/server/modules/document-generation/documentGeneration.service.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { auditEvents, documentGenerationAuditLogs, generatedDocuments } from "../../../drizzle/schema";
+import type { User } from "../../../drizzle/schema";
+import * as repo from "./documentGeneration.repository";
+import * as contextMod from "./promoterAssignmentContext";
+import { DocumentGenerationError } from "./documentGeneration.types";
+import { generateDocument, type GenerateDocumentDeps } from "./documentGeneration.service";
+
+vi.mock("../../db", () => ({
+  getDb: vi.fn(),
+}));
+
+vi.mock("../../storage", () => ({
+  storagePut: vi.fn(),
+}));
+
+import { getDb } from "../../db";
+import { storagePut } from "../../storage";
+
+const user = {
+  id: 1,
+  openId: "o1",
+  email: "a@b.c",
+  name: "U",
+  loginMethod: "manus",
+  role: "user" as const,
+  platformRole: "company_admin" as const,
+  isActive: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  lastSignedIn: new Date(),
+} satisfies User;
+
+const assignmentId = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+const templateRow = {
+  id: "tpl-uuid",
+  companyId: 0,
+  key: "promoter_assignment_contract_bilingual",
+  name: "T",
+  category: "contract",
+  entityType: "promoter_assignment",
+  documentSource: "google_docs",
+  googleDocId: "source-doc",
+  language: "ar-en",
+  version: 1,
+  status: "active",
+  outputFormats: ["pdf"] as string[],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const placeholderRowsFull = [
+  { placeholder: "location_en", sourcePath: "assignment.location_en", dataType: "string", required: true, defaultValue: null },
+];
+
+const contextRoot = {
+  first_party: { company_name_ar: "أ", company_name_en: "A", cr_number: "1" },
+  second_party: { company_name_ar: "ب", company_name_en: "B", cr_number: "2" },
+  promoter: { full_name_ar: "ج", full_name_en: "J D", id_card_number: "99" },
+  assignment: { location_ar: "L1", location_en: "L2", start_date: "2026-01-01", end_date: "2026-06-30" },
+};
+
+describe("generateDocument", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(storagePut).mockResolvedValue({ key: "k", url: "https://u" });
+    vi.spyOn(repo, "seedDocumentGenerationBootstrap").mockResolvedValue();
+    vi.spyOn(repo, "findTemplateByKeyForCompany").mockResolvedValue(templateRow as never);
+    vi.spyOn(repo, "listPlaceholdersForTemplate").mockResolvedValue(placeholderRowsFull as never);
+    vi.spyOn(contextMod, "buildPromoterAssignmentDocumentContext").mockResolvedValue(
+      contextRoot as never
+    );
+  });
+
+  it("happy path with mocked Google and storage", async () => {
+    const insertRecords: { table: unknown; values: Record<string, unknown> }[] = [];
+    const db = {
+      insert: vi.fn((table: object) => ({
+        values: vi.fn((values: Record<string, unknown>) => {
+          insertRecords.push({ table, values });
+          return Promise.resolve();
+        }),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => Promise.resolve()),
+        })),
+      })),
+    };
+    vi.mocked(getDb).mockResolvedValue(db as never);
+
+    const google: GenerateDocumentDeps["google"] = {
+      copyTemplate: vi.fn().mockResolvedValue("new-doc-id"),
+      replacePlaceholders: vi.fn().mockResolvedValue(),
+      exportAsPdf: vi.fn().mockResolvedValue(Buffer.from("%PDF")),
+    };
+
+    const res = await generateDocument(
+      {
+        templateKey: "promoter_assignment_contract_bilingual",
+        entityId: assignmentId,
+        outputFormat: "pdf",
+        actorUserId: 1,
+        user,
+        activeCompanyId: 1,
+        membershipRole: "hr_admin",
+      },
+      { google }
+    );
+
+    expect(res.fileUrl).toBe("https://u");
+    expect(res.generatedGoogleDocId).toBe("new-doc-id");
+    expect(google.copyTemplate).toHaveBeenCalled();
+    expect(storagePut).toHaveBeenCalled();
+    expect(db.insert).toHaveBeenCalledWith(auditEvents);
+    expect(insertRecords.some((r) => r.table === auditEvents)).toBe(true);
+  });
+
+  it("fails when placeholder data missing", async () => {
+    vi.spyOn(repo, "listPlaceholdersForTemplate").mockResolvedValue([
+      {
+        placeholder: "x",
+        sourcePath: "nope.missing",
+        dataType: "string",
+        required: true,
+        defaultValue: null,
+      },
+    ] as never);
+
+    const db = {
+      insert: vi.fn(() => ({ values: vi.fn(() => Promise.resolve()) })),
+      update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })) })),
+    };
+    vi.mocked(getDb).mockResolvedValue(db as never);
+
+    const google: GenerateDocumentDeps["google"] = {
+      copyTemplate: vi.fn(),
+      replacePlaceholders: vi.fn(),
+      exportAsPdf: vi.fn(),
+    };
+
+    await expect(
+      generateDocument(
+        {
+          templateKey: "promoter_assignment_contract_bilingual",
+          entityId: assignmentId,
+          outputFormat: "pdf",
+          actorUserId: 1,
+          user,
+          activeCompanyId: 1,
+          membershipRole: "company_admin",
+        },
+        { google }
+      )
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    expect(google.copyTemplate).not.toHaveBeenCalled();
+  });
+
+  it("fails when entity not in tenant scope", async () => {
+    vi.spyOn(contextMod, "buildPromoterAssignmentDocumentContext").mockRejectedValue(
+      new DocumentGenerationError("NOT_FOUND", "Promoter assignment not found")
+    );
+
+    const db = {
+      insert: vi.fn(() => ({ values: vi.fn(() => Promise.resolve()) })),
+      update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })) })),
+    };
+    vi.mocked(getDb).mockResolvedValue(db as never);
+
+    const google: GenerateDocumentDeps["google"] = {
+      copyTemplate: vi.fn(),
+      replacePlaceholders: vi.fn(),
+      exportAsPdf: vi.fn(),
+    };
+
+    await expect(
+      generateDocument(
+        {
+          templateKey: "promoter_assignment_contract_bilingual",
+          entityId: "cccccccc-cccc-cccc-cccc-cccccccccccc",
+          outputFormat: "pdf",
+          actorUserId: 1,
+          user,
+          activeCompanyId: 1,
+          membershipRole: "company_admin",
+        },
+        { google }
+      )
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("records generation_failed when Google throws", async () => {
+    const insertRecords: { table: unknown; values: Record<string, unknown> }[] = [];
+    const db = {
+      insert: vi.fn((table: object) => ({
+        values: vi.fn((values: Record<string, unknown>) => {
+          insertRecords.push({ table, values });
+          return Promise.resolve();
+        }),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => Promise.resolve()),
+        })),
+      })),
+    };
+    vi.mocked(getDb).mockResolvedValue(db as never);
+
+    const google: GenerateDocumentDeps["google"] = {
+      copyTemplate: vi.fn().mockRejectedValue(new Error("API down")),
+      replacePlaceholders: vi.fn(),
+      exportAsPdf: vi.fn(),
+    };
+
+    await expect(
+      generateDocument(
+        {
+          templateKey: "promoter_assignment_contract_bilingual",
+          entityId: assignmentId,
+          outputFormat: "pdf",
+          actorUserId: 1,
+          user,
+          activeCompanyId: 1,
+          membershipRole: "hr_admin",
+        },
+        { google }
+      )
+    ).rejects.toThrow();
+
+    const failed = insertRecords.find(
+      (r) => r.table === documentGenerationAuditLogs && r.values.action === "generation_failed"
+    );
+    expect(failed).toBeDefined();
+    expect(db.update).toHaveBeenCalledWith(generatedDocuments);
+  });
+});

--- a/server/modules/document-generation/documentGeneration.service.ts
+++ b/server/modules/document-generation/documentGeneration.service.ts
@@ -1,0 +1,240 @@
+import { eq } from "drizzle-orm";
+import { auditEvents, generatedDocuments } from "../../../drizzle/schema";
+import { getDb } from "../../db";
+import { storagePut } from "../../storage";
+import {
+  findTemplateByKeyForCompany,
+  insertDocumentGenerationAuditLog,
+  insertGeneratedDocument,
+  listPlaceholdersForTemplate,
+  seedDocumentGenerationBootstrap,
+} from "./documentGeneration.repository";
+import { buildPromoterAssignmentDocumentContext } from "./promoterAssignmentContext";
+import { resolvePlaceholders, type PlaceholderDefinitionRow } from "./placeholderResolver";
+import {
+  assertOutputFormatAllowed,
+  assertRequiredPlaceholdersResolved,
+  assertTemplateActive,
+} from "./templateValidation";
+import {
+  DocumentGenerationError,
+  type GenerateDocumentInput,
+  type GenerateDocumentResult,
+} from "./documentGeneration.types";
+import type { GoogleDocsClientDeps } from "./googleDocs.client";
+import { createLiveGoogleDocsClient } from "./googleDocs.client";
+
+type AppDb = NonNullable<Awaited<ReturnType<typeof getDb>>>;
+
+export const DOCUMENT_GENERATION_ROLES = ["company_admin", "hr_admin"] as const;
+
+export function canGenerateDocuments(membershipRole: string): boolean {
+  return (DOCUMENT_GENERATION_ROLES as readonly string[]).includes(membershipRole);
+}
+
+/** Stable positive int for audit_events.entityId when the domain entity uses a UUID string. */
+export function hashUuidToAuditEntityId(uuid: string): number {
+  let h = 0;
+  for (let i = 0; i < uuid.length; i++) {
+    h = (Math.imul(31, h) + uuid.charCodeAt(i)) | 0;
+  }
+  const n = Math.abs(h);
+  return n === 0 ? 1 : n;
+}
+
+async function buildEntityContext(
+  db: AppDb,
+  entityType: string,
+  entityId: string,
+  activeCompanyId: number,
+  user: GenerateDocumentInput["user"]
+): Promise<Record<string, unknown>> {
+  if (entityType === "promoter_assignment") {
+    const ctx = await buildPromoterAssignmentDocumentContext(db, entityId, activeCompanyId, user);
+    return ctx as unknown as Record<string, unknown>;
+  }
+  throw new DocumentGenerationError(
+    "VALIDATION_ERROR",
+    `No context builder registered for entity type "${entityType}"`
+  );
+}
+
+export type GenerateDocumentDeps = {
+  google: GoogleDocsClientDeps;
+};
+
+const defaultDeps: GenerateDocumentDeps = {
+  google: createLiveGoogleDocsClient(),
+};
+
+export async function generateDocument(
+  input: GenerateDocumentInput,
+  deps: GenerateDocumentDeps = defaultDeps
+): Promise<GenerateDocumentResult> {
+  const db = await getDb();
+  if (!db) {
+    throw new DocumentGenerationError("INTERNAL_ERROR", "Database unavailable");
+  }
+
+  if (!canGenerateDocuments(input.membershipRole)) {
+    throw new DocumentGenerationError(
+      "FORBIDDEN",
+      "You do not have permission to generate this document."
+    );
+  }
+
+  await seedDocumentGenerationBootstrap(db);
+
+  const template = await findTemplateByKeyForCompany(db, input.templateKey, input.activeCompanyId);
+  if (!template) {
+    throw new DocumentGenerationError("NOT_FOUND", `Document template "${input.templateKey}" not found`);
+  }
+
+  assertTemplateActive(template);
+  assertOutputFormatAllowed(template, input.outputFormat);
+
+  const placeholderRows = await listPlaceholdersForTemplate(db, template.id);
+  const defs: PlaceholderDefinitionRow[] = placeholderRows.map((p) => ({
+    placeholder: p.placeholder,
+    sourcePath: p.sourcePath,
+    dataType: p.dataType,
+    required: p.required,
+    defaultValue: p.defaultValue,
+  }));
+
+  const contextRoot = await buildEntityContext(
+    db,
+    template.entityType,
+    input.entityId,
+    input.activeCompanyId,
+    input.user
+  );
+
+  const { values, missing } = resolvePlaceholders(defs, contextRoot);
+  assertRequiredPlaceholdersResolved(missing);
+
+  const documentId = crypto.randomUUID();
+  const sourceDocId = template.googleDocId;
+  if (!sourceDocId) {
+    throw new DocumentGenerationError("INTERNAL_ERROR", "Template has no google_doc_id configured");
+  }
+
+  const auditBase = {
+    templateKey: input.templateKey,
+    entityId: input.entityId,
+    entityType: template.entityType,
+    tenantId: input.activeCompanyId,
+    outputFormat: input.outputFormat,
+    sourceGoogleDocId: sourceDocId,
+  };
+
+  await insertGeneratedDocument(db, {
+    id: documentId,
+    templateId: template.id,
+    entityType: template.entityType,
+    entityId: input.entityId,
+    outputFormat: input.outputFormat,
+    sourceGoogleDocId: sourceDocId,
+    generatedGoogleDocId: null,
+    fileUrl: null,
+    filePath: null,
+    status: "pending",
+    generatedBy: input.actorUserId,
+    companyId: input.activeCompanyId,
+    metadata: {
+      templateKey: input.templateKey,
+      templateName: template.name,
+    },
+  });
+
+  await insertDocumentGenerationAuditLog(db, {
+    id: crypto.randomUUID(),
+    generatedDocumentId: documentId,
+    action: "generation_requested",
+    actorId: input.actorUserId,
+    details: auditBase,
+  });
+
+  let generatedGoogleDocId = "";
+  let pdfBuffer: Buffer;
+
+  try {
+    generatedGoogleDocId = await deps.google.copyTemplate(
+      sourceDocId,
+      `${template.name} — ${input.entityId}`
+    );
+    await deps.google.replacePlaceholders(generatedGoogleDocId, values);
+    pdfBuffer = await deps.google.exportAsPdf(generatedGoogleDocId);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const code = e instanceof DocumentGenerationError ? e.code : "INTERNAL_ERROR";
+    await insertDocumentGenerationAuditLog(db, {
+      id: crypto.randomUUID(),
+      generatedDocumentId: documentId,
+      action: "generation_failed",
+      actorId: input.actorUserId,
+      details: { ...auditBase, error: msg, code },
+    });
+    await db
+      .update(generatedDocuments)
+      .set({ status: "failed", metadata: { templateKey: input.templateKey, error: msg } })
+      .where(eq(generatedDocuments.id, documentId));
+    throw e;
+  }
+
+  const day = new Date().toISOString().slice(0, 10);
+  const storageKey = `generated-docs/${input.activeCompanyId}/${template.key}/${input.entityId}/${day}/${documentId}.pdf`;
+  const { url: fileUrl, key: filePath } = await storagePut(storageKey, pdfBuffer, "application/pdf");
+
+  await db
+    .update(generatedDocuments)
+    .set({
+      generatedGoogleDocId,
+      fileUrl,
+      filePath,
+      status: "generated",
+      metadata: {
+        templateKey: input.templateKey,
+        templateName: template.name,
+      },
+    })
+    .where(eq(generatedDocuments.id, documentId));
+
+  await insertDocumentGenerationAuditLog(db, {
+    id: crypto.randomUUID(),
+    generatedDocumentId: documentId,
+    action: "generation_completed",
+    actorId: input.actorUserId,
+    details: {
+      ...auditBase,
+      generatedGoogleDocId,
+      fileUrl,
+      filePath,
+      documentId,
+    },
+  });
+
+  await db.insert(auditEvents).values({
+    companyId: input.activeCompanyId,
+    actorUserId: input.actorUserId,
+    entityType: "generated_document",
+    entityId: hashUuidToAuditEntityId(documentId),
+    action: "document_generated",
+    metadata: {
+      templateKey: input.templateKey,
+      entityType: template.entityType,
+      entityId: input.entityId,
+      documentId,
+      filePath,
+      outputFormat: input.outputFormat,
+    },
+  });
+
+  return {
+    documentId,
+    fileUrl,
+    filePath,
+    generatedGoogleDocId,
+    missingFields: [],
+  };
+}

--- a/server/modules/document-generation/documentGeneration.types.ts
+++ b/server/modules/document-generation/documentGeneration.types.ts
@@ -1,0 +1,77 @@
+import type { User } from "../../../drizzle/schema";
+
+/** Normalized context for promoter assignment contracts (placeholder source paths). */
+export type PromoterAssignmentDocumentContext = {
+  first_party: {
+    company_name_ar: string;
+    company_name_en: string;
+    cr_number: string;
+  };
+  second_party: {
+    company_name_ar: string;
+    company_name_en: string;
+    cr_number: string;
+  };
+  promoter: {
+    full_name_ar: string;
+    full_name_en: string;
+    id_card_number: string;
+  };
+  assignment: {
+    location_ar: string;
+    location_en: string;
+    start_date: string;
+    end_date: string;
+    contract_reference_number?: string;
+    issue_date?: string;
+  };
+};
+
+export type DocumentGenerationErrorCode =
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "VALIDATION_ERROR"
+  | "NOT_FOUND"
+  | "INTERNAL_ERROR";
+
+export class DocumentGenerationError extends Error {
+  readonly code: DocumentGenerationErrorCode;
+  readonly missingPlaceholders?: string[];
+  readonly causeDetail?: unknown;
+
+  constructor(
+    code: DocumentGenerationErrorCode,
+    message: string,
+    options?: { missingPlaceholders?: string[]; cause?: unknown }
+  ) {
+    super(message);
+    this.name = "DocumentGenerationError";
+    this.code = code;
+    this.missingPlaceholders = options?.missingPlaceholders;
+    this.causeDetail = options?.cause;
+  }
+}
+
+export type GenerateDocumentInput = {
+  templateKey: string;
+  entityId: string;
+  outputFormat: "pdf";
+  actorUserId: number;
+  user: User;
+  activeCompanyId: number;
+  membershipRole: string;
+};
+
+export type GenerateDocumentResult = {
+  documentId: string;
+  fileUrl: string;
+  filePath: string;
+  generatedGoogleDocId: string;
+  missingFields: string[];
+};
+
+export type AuthLikeContext = {
+  user: User;
+  activeCompanyId: number;
+  membershipRole: string;
+};

--- a/server/modules/document-generation/googleDocs.client.ts
+++ b/server/modules/document-generation/googleDocs.client.ts
@@ -1,0 +1,117 @@
+import { google } from "googleapis";
+import { JWT } from "google-auth-library";
+import { ENV } from "../../_core/env";
+import { DocumentGenerationError } from "./documentGeneration.types";
+
+const DRIVE_FILE_SCOPE = "https://www.googleapis.com/auth/drive";
+const DOCS_SCOPE = "https://www.googleapis.com/auth/documents";
+
+function parseServiceAccount(): { clientEmail: string; privateKey: string } {
+  const raw = ENV.googleDocsServiceAccountJson?.trim();
+  if (!raw) {
+    throw new DocumentGenerationError(
+      "INTERNAL_ERROR",
+      "Google Docs is not configured: set GOOGLE_DOCS_SERVICE_ACCOUNT_JSON"
+    );
+  }
+  try {
+    const j = JSON.parse(raw) as { client_email?: string; private_key?: string };
+    if (!j.client_email || !j.private_key) {
+      throw new Error("service account JSON must include client_email and private_key");
+    }
+    return { clientEmail: j.client_email, privateKey: j.private_key.replace(/\\n/g, "\n") };
+  } catch (e) {
+    throw new DocumentGenerationError(
+      "INTERNAL_ERROR",
+      "Invalid GOOGLE_DOCS_SERVICE_ACCOUNT_JSON",
+      { cause: e }
+    );
+  }
+}
+
+function createJwtClient(): JWT {
+  const { clientEmail, privateKey } = parseServiceAccount();
+  return new JWT({
+    email: clientEmail,
+    key: privateKey,
+    scopes: [DRIVE_FILE_SCOPE, DOCS_SCOPE],
+  });
+}
+
+export type GoogleDocsClientDeps = {
+  copyTemplate: (templateGoogleDocId: string, title?: string) => Promise<string>;
+  replacePlaceholders: (googleDocId: string, values: Record<string, string>) => Promise<void>;
+  exportAsPdf: (googleDocId: string) => Promise<Buffer>;
+};
+
+function wrapGoogleError(e: unknown, message: string): never {
+  const err = e as { message?: string; code?: number; errors?: { message?: string }[] };
+  const detail = err?.errors?.[0]?.message ?? err?.message ?? String(e);
+  throw new DocumentGenerationError("INTERNAL_ERROR", `${message}: ${detail}`, { cause: e });
+}
+
+export function createLiveGoogleDocsClient(): GoogleDocsClientDeps {
+  let jwt: JWT | null = null;
+  const getJwt = async () => {
+    if (!jwt) jwt = createJwtClient();
+    return jwt;
+  };
+
+  return {
+    async copyTemplate(templateGoogleDocId: string, title?: string): Promise<string> {
+      try {
+        const auth = await getJwt();
+        const drive = google.drive({ version: "v3", auth });
+        const res = await drive.files.copy({
+          fileId: templateGoogleDocId,
+          requestBody: {
+            name: title ?? `Generated ${new Date().toISOString().slice(0, 10)}`,
+          },
+          fields: "id",
+        });
+        const id = res.data.id;
+        if (!id) throw new Error("Drive copy returned no file id");
+        return id;
+      } catch (e) {
+        return wrapGoogleError(e, "Failed to copy Google Doc template");
+      }
+    },
+
+    async replacePlaceholders(googleDocId: string, values: Record<string, string>): Promise<void> {
+      try {
+        const auth = await getJwt();
+        const docs = google.docs({ version: "v1", auth });
+        const requests = Object.entries(values).map(([key, text]) => ({
+          replaceAllText: {
+            containsText: {
+              text: `{{${key}}}`,
+              matchCase: true,
+            },
+            replaceText: text,
+          },
+        }));
+        if (requests.length === 0) return;
+        await docs.documents.batchUpdate({
+          documentId: googleDocId,
+          requestBody: { requests },
+        });
+      } catch (e) {
+        return wrapGoogleError(e, "Failed to replace placeholders in Google Doc");
+      }
+    },
+
+    async exportAsPdf(googleDocId: string): Promise<Buffer> {
+      try {
+        const auth = await getJwt();
+        const drive = google.drive({ version: "v3", auth });
+        const res = await drive.files.export(
+          { fileId: googleDocId, mimeType: "application/pdf" },
+          { responseType: "arraybuffer" }
+        );
+        return Buffer.from(res.data as ArrayBuffer);
+      } catch (e) {
+        return wrapGoogleError(e, "Failed to export Google Doc as PDF");
+      }
+    },
+  };
+}

--- a/server/modules/document-generation/placeholderResolver.test.ts
+++ b/server/modules/document-generation/placeholderResolver.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { formatDateValue, resolvePlaceholders, type PlaceholderDefinitionRow } from "./placeholderResolver";
+
+describe("placeholderResolver", () => {
+  const defs: PlaceholderDefinitionRow[] = [
+    {
+      placeholder: "name",
+      sourcePath: "user.name",
+      dataType: "string",
+      required: true,
+      defaultValue: null,
+    },
+    {
+      placeholder: "start",
+      sourcePath: "period.start",
+      dataType: "date",
+      required: true,
+      defaultValue: null,
+    },
+    {
+      placeholder: "opt",
+      sourcePath: "misc.note",
+      dataType: "string",
+      required: false,
+      defaultValue: null,
+    },
+  ];
+
+  it("resolves values by source_path", () => {
+    const ctx = {
+      user: { name: "  Acme  " },
+      period: { start: "2026-01-15" },
+      misc: {},
+    };
+    const { values, missing } = resolvePlaceholders(defs, ctx);
+    expect(values.name).toBe("  Acme  ");
+    expect(values.start).toBe("2026-01-15");
+    expect(missing).not.toContain("name");
+    expect(missing).not.toContain("start");
+  });
+
+  it("reports missing required placeholders", () => {
+    const { values, missing } = resolvePlaceholders(defs, {
+      user: { name: "" },
+      period: {},
+      misc: {},
+    });
+    expect(values).toEqual({});
+    expect(missing).toContain("name");
+    expect(missing).toContain("start");
+  });
+
+  it("formats dates consistently", () => {
+    expect(formatDateValue(new Date("2026-04-05T12:00:00Z"))).toBe("2026-04-05");
+    expect(formatDateValue("2026-12-01")).toBe("2026-12-01");
+  });
+
+  it("uses default_value when raw is missing", () => {
+    const withDefault: PlaceholderDefinitionRow[] = [
+      {
+        placeholder: "x",
+        sourcePath: "a.b",
+        dataType: "string",
+        required: true,
+        defaultValue: "fallback",
+      },
+    ];
+    const { values, missing } = resolvePlaceholders(withDefault, { a: {} });
+    expect(values.x).toBe("fallback");
+    expect(missing).toHaveLength(0);
+  });
+});

--- a/server/modules/document-generation/placeholderResolver.ts
+++ b/server/modules/document-generation/placeholderResolver.ts
@@ -1,0 +1,84 @@
+import { format } from "date-fns";
+
+export type PlaceholderDefinitionRow = {
+  placeholder: string;
+  sourcePath: string;
+  dataType: string;
+  required: boolean;
+  defaultValue: string | null;
+};
+
+const DATE_DISPLAY_FORMAT = "yyyy-MM-dd";
+
+function getByPath(root: unknown, path: string): unknown {
+  const segments = path.split(".").filter(Boolean);
+  let cur: unknown = root;
+  for (const seg of segments) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[seg];
+  }
+  return cur;
+}
+
+function isEmptyString(v: string): boolean {
+  return v.trim().length === 0;
+}
+
+export function formatDateValue(value: unknown): string | null {
+  if (value == null) return null;
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return format(value, DATE_DISPLAY_FORMAT);
+  }
+  if (typeof value === "string") {
+    const t = Date.parse(value);
+    if (!Number.isNaN(t)) return format(new Date(t), DATE_DISPLAY_FORMAT);
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value.trim())) return value.trim();
+  }
+  return null;
+}
+
+function formatStringValue(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  if (typeof value === "string") {
+    return isEmptyString(value) ? null : value;
+  }
+  return null;
+}
+
+/**
+ * Resolves template placeholders from a nested context object using dot paths.
+ * Returns string values keyed by placeholder token (without braces) and a list of missing required keys.
+ */
+export function resolvePlaceholders(
+  definitions: PlaceholderDefinitionRow[],
+  contextRoot: Record<string, unknown>
+): { values: Record<string, string>; missing: string[] } {
+  const values: Record<string, string> = {};
+  const missing: string[] = [];
+
+  for (const def of definitions) {
+    const raw = getByPath(contextRoot, def.sourcePath);
+    let out: string | null = null;
+
+    if (def.dataType === "date") {
+      out = formatDateValue(raw);
+    } else {
+      out = formatStringValue(raw);
+    }
+
+    if (out == null && def.defaultValue != null && def.defaultValue !== "") {
+      out = def.defaultValue;
+    }
+
+    if (out == null || isEmptyString(out)) {
+      if (def.required) missing.push(def.placeholder);
+      continue;
+    }
+
+    values[def.placeholder] = out;
+  }
+
+  return { values, missing };
+}

--- a/server/modules/document-generation/promoterAssignmentContext.test.ts
+++ b/server/modules/document-generation/promoterAssignmentContext.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { companies, employees, promoterAssignments } from "../../../drizzle/schema";
+import { buildPromoterAssignmentDocumentContext } from "./promoterAssignmentContext";
+
+function mockDb(handlers: {
+  assignment?: unknown[];
+  companies?: unknown[];
+  employees?: unknown[];
+}) {
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn((table: object) => {
+        if (table === promoterAssignments) {
+          return {
+            where: vi.fn(() => ({
+              limit: vi.fn(() => Promise.resolve(handlers.assignment ?? [])),
+            })),
+          };
+        }
+        if (table === companies) {
+          return {
+            where: vi.fn(() => Promise.resolve(handlers.companies ?? [])),
+          };
+        }
+        if (table === employees) {
+          return {
+            where: vi.fn(() => ({
+              limit: vi.fn(() => Promise.resolve(handlers.employees ?? [])),
+            })),
+          };
+        }
+        return {
+          where: vi.fn(() => ({
+            limit: vi.fn(() => Promise.resolve([])),
+          })),
+        };
+      }),
+    })),
+  } as never;
+}
+
+describe("buildPromoterAssignmentDocumentContext", () => {
+  const entityId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+  const firstCo = {
+    id: 1,
+    name: "First EN",
+    nameAr: "First AR",
+    crNumber: "CR1",
+    registrationNumber: null,
+  };
+  const secondCo = {
+    id: 2,
+    name: "Second EN",
+    nameAr: "Second AR",
+    crNumber: "CR2",
+    registrationNumber: null,
+  };
+  const employee = {
+    id: 10,
+    companyId: 1,
+    firstName: "John",
+    lastName: "Doe",
+    firstNameAr: "جون",
+    lastNameAr: "دو",
+    nationalId: "12345678",
+    passportNumber: null,
+  };
+
+  const baseAssignment = {
+    id: entityId,
+    companyId: 1,
+    firstPartyCompanyId: 1,
+    secondPartyCompanyId: 2,
+    promoterEmployeeId: 10,
+    locationAr: "مسقط",
+    locationEn: "Muscat",
+    startDate: "2026-01-01",
+    endDate: "2026-12-31",
+    status: "active",
+    contractReferenceNumber: null,
+    issueDate: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  it("returns normalized context when tenant matches assignment company", async () => {
+    const db = mockDb({
+      assignment: [baseAssignment],
+      companies: [firstCo, secondCo],
+      employees: [employee],
+    });
+
+    const ctx = await buildPromoterAssignmentDocumentContext(db, entityId, 1, {
+      id: 99,
+      role: "user",
+      platformRole: "company_member",
+    });
+
+    expect(ctx.first_party.company_name_en).toBe("First EN");
+    expect(ctx.second_party.cr_number).toBe("CR2");
+    expect(ctx.promoter.id_card_number).toBe("12345678");
+    expect(ctx.assignment.start_date).toBe("2026-01-01");
+  });
+
+  it("throws FORBIDDEN when assignment belongs to another company", async () => {
+    const db = mockDb({
+      assignment: [{ ...baseAssignment, companyId: 99 }],
+      companies: [firstCo, secondCo],
+      employees: [employee],
+    });
+
+    await expect(
+      buildPromoterAssignmentDocumentContext(db, entityId, 1, {
+        id: 1,
+        platformRole: "company_member",
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});

--- a/server/modules/document-generation/promoterAssignmentContext.ts
+++ b/server/modules/document-generation/promoterAssignmentContext.ts
@@ -1,0 +1,137 @@
+import { and, eq, inArray, or } from "drizzle-orm";
+import {
+  companies,
+  employees,
+  promoterAssignments,
+} from "../../../drizzle/schema";
+import { format } from "date-fns";
+import { canAccessGlobalAdminProcedures } from "@shared/rbac";
+import type { getDb } from "../../db";
+import { DocumentGenerationError, type PromoterAssignmentDocumentContext } from "./documentGeneration.types";
+
+type AppDb = NonNullable<Awaited<ReturnType<typeof getDb>>>;
+
+function sqlDateToIso(d: Date | string): string {
+  if (typeof d === "string") return d.slice(0, 10);
+  return format(d, "yyyy-MM-dd");
+}
+
+function nonEmptyOrThrow(label: string, v: string | null | undefined): string {
+  const s = (v ?? "").trim();
+  if (!s) {
+    throw new DocumentGenerationError("VALIDATION_ERROR", `${label} is required`);
+  }
+  return s;
+}
+
+/**
+ * Loads promoter assignment and related companies/employee for document placeholders.
+ * Enforces tenant: assignment must belong to active company OR user is platform admin
+ * and assignment involves that company as first/second party.
+ */
+export async function buildPromoterAssignmentDocumentContext(
+  db: AppDb,
+  entityId: string,
+  activeCompanyId: number,
+  user: { id: number; role?: string | null; platformRole?: string | null }
+): Promise<PromoterAssignmentDocumentContext> {
+  const [row] = await db
+    .select()
+    .from(promoterAssignments)
+    .where(eq(promoterAssignments.id, entityId))
+    .limit(1);
+
+  if (!row) {
+    throw new DocumentGenerationError("NOT_FOUND", "Promoter assignment not found");
+  }
+
+  const isPlatform = canAccessGlobalAdminProcedures(user);
+  const inTenant =
+    row.companyId === activeCompanyId ||
+    row.firstPartyCompanyId === activeCompanyId ||
+    row.secondPartyCompanyId === activeCompanyId;
+
+  if (!isPlatform && !inTenant) {
+    throw new DocumentGenerationError("FORBIDDEN", "Promoter assignment is not in your company scope");
+  }
+
+  if (!isPlatform && row.companyId !== activeCompanyId) {
+    throw new DocumentGenerationError("FORBIDDEN", "Promoter assignment does not belong to your active company");
+  }
+
+  const companyIds = [row.firstPartyCompanyId, row.secondPartyCompanyId];
+  const coRows = await db
+    .select()
+    .from(companies)
+    .where(inArray(companies.id, companyIds));
+
+  const byId = new Map(coRows.map((c) => [c.id, c]));
+  const firstParty = byId.get(row.firstPartyCompanyId);
+  const secondParty = byId.get(row.secondPartyCompanyId);
+  if (!firstParty || !secondParty) {
+    throw new DocumentGenerationError("INTERNAL_ERROR", "Related company record missing for assignment");
+  }
+
+  const empList = await db
+    .select()
+    .from(employees)
+    .where(
+      and(
+        eq(employees.id, row.promoterEmployeeId),
+        or(
+          eq(employees.companyId, row.firstPartyCompanyId),
+          eq(employees.companyId, row.secondPartyCompanyId),
+          eq(employees.companyId, row.companyId)
+        )
+      )
+    )
+    .limit(1);
+
+  const promoter = empList[0];
+  if (!promoter) {
+    throw new DocumentGenerationError("NOT_FOUND", "Promoter employee not found for this assignment");
+  }
+
+  const fullNameEn = nonEmptyOrThrow(
+    "Promoter English name",
+    `${promoter.firstName ?? ""} ${promoter.lastName ?? ""}`.trim() || null
+  );
+  const fullNameAr = nonEmptyOrThrow(
+    "Promoter Arabic name",
+    `${promoter.firstNameAr ?? ""} ${promoter.lastNameAr ?? ""}`.trim() ||
+      `${promoter.firstName ?? ""} ${promoter.lastName ?? ""}`.trim()
+  );
+
+  const ctx: PromoterAssignmentDocumentContext = {
+    first_party: {
+      company_name_ar: nonEmptyOrThrow("First party Arabic name", firstParty.nameAr ?? firstParty.name),
+      company_name_en: nonEmptyOrThrow("First party English name", firstParty.name),
+      cr_number: nonEmptyOrThrow("First party CR number", firstParty.crNumber ?? firstParty.registrationNumber),
+    },
+    second_party: {
+      company_name_ar: nonEmptyOrThrow("Second party Arabic name", secondParty.nameAr ?? secondParty.name),
+      company_name_en: nonEmptyOrThrow("Second party English name", secondParty.name),
+      cr_number: nonEmptyOrThrow("Second party CR number", secondParty.crNumber ?? secondParty.registrationNumber),
+    },
+    promoter: {
+      full_name_ar: fullNameAr,
+      full_name_en: fullNameEn,
+      id_card_number: nonEmptyOrThrow("Promoter ID card number", promoter.nationalId ?? promoter.passportNumber),
+    },
+    assignment: {
+      location_ar: nonEmptyOrThrow("Location (Arabic)", row.locationAr),
+      location_en: nonEmptyOrThrow("Location (English)", row.locationEn),
+      start_date: sqlDateToIso(row.startDate),
+      end_date: sqlDateToIso(row.endDate),
+    },
+  };
+
+  if (row.contractReferenceNumber?.trim()) {
+    ctx.assignment.contract_reference_number = row.contractReferenceNumber.trim();
+  }
+  if (row.issueDate) {
+    ctx.assignment.issue_date = sqlDateToIso(row.issueDate);
+  }
+
+  return ctx;
+}

--- a/server/modules/document-generation/templateValidation.test.ts
+++ b/server/modules/document-generation/templateValidation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { DocumentGenerationError } from "./documentGeneration.types";
+import {
+  assertOutputFormatAllowed,
+  assertRequiredPlaceholdersResolved,
+  assertTemplateActive,
+} from "./templateValidation";
+import type { DocumentTemplate } from "../../../drizzle/schema";
+
+function tpl(partial: Partial<DocumentTemplate>): DocumentTemplate {
+  return {
+    id: "t1",
+    companyId: 0,
+    key: "k",
+    name: "n",
+    category: "c",
+    entityType: "promoter_assignment",
+    documentSource: "google_docs",
+    googleDocId: "gid",
+    language: "en",
+    version: 1,
+    status: "active",
+    outputFormats: ["pdf"],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...partial,
+  } as DocumentTemplate;
+}
+
+describe("templateValidation", () => {
+  it("assertTemplateActive throws for non-active", () => {
+    expect(() => assertTemplateActive(tpl({ status: "draft" }))).toThrow(DocumentGenerationError);
+    expect(() => assertTemplateActive(tpl({ status: "active" }))).not.toThrow();
+  });
+
+  it("assertOutputFormatAllowed checks json list", () => {
+    expect(() => assertOutputFormatAllowed(tpl({ outputFormats: ["pdf"] }), "pdf")).not.toThrow();
+    expect(() => assertOutputFormatAllowed(tpl({ outputFormats: ["pdf"] }), "docx")).toThrow(
+      DocumentGenerationError
+    );
+  });
+
+  it("assertRequiredPlaceholdersResolved lists missing", () => {
+    expect(() => assertRequiredPlaceholdersResolved(["a", "b"])).toThrow(DocumentGenerationError);
+    try {
+      assertRequiredPlaceholdersResolved(["x"]);
+    } catch (e) {
+      expect(e).toBeInstanceOf(DocumentGenerationError);
+      expect((e as DocumentGenerationError).missingPlaceholders).toEqual(["x"]);
+    }
+    expect(() => assertRequiredPlaceholdersResolved([])).not.toThrow();
+  });
+});

--- a/server/modules/document-generation/templateValidation.ts
+++ b/server/modules/document-generation/templateValidation.ts
@@ -1,0 +1,51 @@
+import type { DocumentTemplate, DocumentTemplatePlaceholder } from "../../../drizzle/schema";
+import { DocumentGenerationError } from "./documentGeneration.types";
+
+export type TemplateWithPlaceholders = {
+  template: DocumentTemplate;
+  placeholders: DocumentTemplatePlaceholder[];
+};
+
+export function assertOutputFormatAllowed(
+  template: DocumentTemplate,
+  outputFormat: string
+): void {
+  const allowed = template.outputFormats ?? [];
+  if (!allowed.includes(outputFormat)) {
+    throw new DocumentGenerationError(
+      "VALIDATION_ERROR",
+      `Output format "${outputFormat}" is not allowed for this template. Allowed: ${allowed.join(", ")}`
+    );
+  }
+}
+
+export function assertTemplateActive(template: DocumentTemplate): void {
+  if (template.status !== "active") {
+    throw new DocumentGenerationError(
+      "VALIDATION_ERROR",
+      `Template "${template.key}" is not active (status: ${template.status}).`
+    );
+  }
+}
+
+export function assertEntityTypeMatches(
+  template: DocumentTemplate,
+  entityType: string
+): void {
+  if (template.entityType !== entityType) {
+    throw new DocumentGenerationError(
+      "VALIDATION_ERROR",
+      `Template is for entity type "${template.entityType}", not "${entityType}".`
+    );
+  }
+}
+
+export function assertRequiredPlaceholdersResolved(missing: string[]): void {
+  if (missing.length > 0) {
+    throw new DocumentGenerationError(
+      "VALIDATION_ERROR",
+      `Missing required document data: ${missing.join(", ")}`,
+      { missingPlaceholders: missing }
+    );
+  }
+}

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -42,6 +42,7 @@ import { workLogsRouter } from "./routers/workLogs";
 import { financeHRRouter } from "./routers/financeHR";
 import { automationRouter } from "./routers/automation";
 import { automationSlaRouter } from "./routers/automationSla";
+import { documentGenerationRouter } from "./routers/documentGeneration";
 
 export const appRouter = router({
   system: systemRouter,
@@ -95,6 +96,7 @@ export const appRouter = router({
   financeHR: financeHRRouter,
   automation: automationRouter,
   automationSla: automationSlaRouter,
+  documentGeneration: documentGenerationRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/server/routers/documentGeneration.ts
+++ b/server/routers/documentGeneration.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import {
+  getActiveCompanyMembership,
+  requireNotAuditor,
+} from "../_core/membership";
+import { requireActiveCompanyId } from "../_core/tenant";
+import { protectedProcedure, router } from "../_core/trpc";
+import {
+  DocumentGenerationError,
+} from "../modules/document-generation/documentGeneration.types";
+import {
+  canGenerateDocuments,
+  generateDocument,
+} from "../modules/document-generation/documentGeneration.service";
+
+function mapDocGenError(e: unknown): never {
+  if (e instanceof DocumentGenerationError) {
+    const codeMap: Record<DocumentGenerationError["code"], TRPCError["code"]> = {
+      UNAUTHORIZED: "UNAUTHORIZED",
+      FORBIDDEN: "FORBIDDEN",
+      VALIDATION_ERROR: "BAD_REQUEST",
+      NOT_FOUND: "NOT_FOUND",
+      INTERNAL_ERROR: "INTERNAL_SERVER_ERROR",
+    };
+    throw new TRPCError({
+      code: codeMap[e.code],
+      message: e.message,
+      cause: e,
+    });
+  }
+  throw e;
+}
+
+export const documentGenerationRouter = router({
+  generate: protectedProcedure
+    .input(
+      z.object({
+        templateKey: z.string().min(1),
+        entityId: z.string().uuid(),
+        outputFormat: z.enum(["pdf"]),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const companyId = await requireActiveCompanyId(ctx.user.id);
+      const membership = await getActiveCompanyMembership(ctx.user.id, companyId);
+      if (!membership) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "No company membership" });
+      }
+      requireNotAuditor(membership.role);
+      if (!canGenerateDocuments(membership.role)) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You do not have permission to generate documents.",
+        });
+      }
+
+      try {
+        return await generateDocument({
+          templateKey: input.templateKey,
+          entityId: input.entityId,
+          outputFormat: input.outputFormat,
+          actorUserId: ctx.user.id,
+          user: ctx.user,
+          activeCompanyId: companyId,
+          membershipRole: membership.role,
+        });
+      } catch (e) {
+        mapDocGenError(e);
+      }
+    }),
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a server-authoritative document generation flow: load template metadata from the database, build tenant-scoped context for promoter assignments, resolve placeholders, copy a Google Docs template, replace `{{placeholder}}` tokens, export PDF, upload via the existing Forge storage proxy, and persist `generated_documents` plus `document_generation_audit_logs` and an `audit_events` row.

## Promoter assignments (client / employer / promoter)

- **First party** = **client** (e.g. eXtra). **Second party** = **employer** (e.g. Falcon Eye Modern Investments). **Promoter** = employee of the **employer** only.
- **Work location** text in the contract always describes the **client’s** site (where the promoter works); it is **not** the employer’s HQ.
- Optional **`client_site_id`**: FK to **`attendance_sites`** where `company_id` = client, so assignments can link to a saved client branch/site. Migration `0017_promoter_assignment_client_site.sql`.
- tRPC: `listClientWorkLocations`, `companiesForPartyPickers`, `listEmployerEmployees`, `create`, `list`.
- Contracts UI: order is **Client → Client work location (site picker) → EN/AR work address → Employer → Promoter**; picking a site fills the location fields.

## Database

- Tables: `promoter_assignments` (+ `client_site_id`), `document_templates`, `document_template_placeholders`, `generated_documents`, `document_generation_audit_logs`.
- Migrations: `0016_document_generation.sql`, `0017_promoter_assignment_client_site.sql`.

## API

- `documentGeneration.generate` — roles `company_admin` / `hr_admin`.

## Configuration

- `GOOGLE_DOCS_SERVICE_ACCOUNT_JSON`, Forge storage env vars.

## Notes

- Client sites come from **Attendance** sites for that client company; ensure eXtra (or the client) has sites configured if you use the picker.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d954ee6d-0ee3-4efd-b77f-11dada2217ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d954ee6d-0ee3-4efd-b77f-11dada2217ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

